### PR TITLE
bugfix/commonjs-module

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,8 @@
     "@types/react-dom": "^16.9.5",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-scripts": "3.3.0",
+    "react-scripts": "^3.4.1",
+    "recost": "file:..",
     "typescript": "^3.7.5"
   },
   "scripts": {

--- a/example/src/reducers/index.ts
+++ b/example/src/reducers/index.ts
@@ -1,4 +1,4 @@
-import recost, { IBaseState } from 'recost'
+import recost from 'recost'
 import * as logger from '../utils/logger'
 import * as callAPI from '../utils/callAPI'
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
-import React, { Props, ReactElement, ComponentType, Component } from 'react'
+import * as React from 'react'
+import { Props, ReactElement, ComponentType, Component } from 'react'
 
 export interface IAction {
   type: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "module": "commonjs",
     "outDir": "./lib",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",


### PR DESCRIPTION
Add commonjs support to recost.

For server-side rendering with NodeJs, ES6 modules are not supported.
This PR adds commonjs support to recost so it can be used with NextJS for example.
